### PR TITLE
fix: snapshot injection in case of adapter usage

### DIFF
--- a/lib/loader.js
+++ b/lib/loader.js
@@ -42,8 +42,12 @@ module.exports.loader = function loader(devtoolsRegisterOpts) {
 
   NestFactory.create = function create(...args) {
     // create(module, options)
+    // create(module, httpAdapter)
     // create(module, httpAdapter, options)
-    const optsIdx = args.length === 3 ? 2 : 1
+    let optsIdx = 1;
+    if(args.length === 3 || (args.length === 2 && typeof args[1] === "object" && Object.getPrototypeOf(args[1].constructor).name === "AbstractHttpAdapter")){
+      optsIdx = 2;
+    }
 
     /** @type {import('@nestjs/common').NestApplicationOptions} */
     const optsToMerge = {


### PR DESCRIPTION
Hello, thanks for your code!
I notice an unexpected behavior in case of adapter usage.
My bootstrap code is
`
    const app = await NestFactory.create<NestFastifyApplication>(
        AppModule,
        new FastifyAdapter()
    );
`
an the loader class try to inject the "snapshot: true" property in the wrong position.
Here my fix

A.